### PR TITLE
fix(error):  remove discordClientException from ytdl error event

### DIFF
--- a/src/discord/services/discord.client.service.ts
+++ b/src/discord/services/discord.client.service.ts
@@ -259,7 +259,6 @@ export class DiscordClientService {
             liveBuffer: 4000,
         }).on('error', (error: any) => {
             this.logger.error(error)
-            throw new DiscordClientException(this.playSong.name, error.message)
         })
 
         const resource: AudioResource = createAudioResource(stream, {inputType: StreamType.Arbitrary})


### PR DESCRIPTION
# Description

- ytdl error event에서 `DiscordClientException`을 발생시키지 않도록 수정 (`videoId`에 해당하는 영상이 유튜브에서 지워졌을 때 에러 발생)