### PR TITLE
fix(db): add keepConnectionAlive option, remove unnecessary forwardRef

### DIFF
--- a/src/common/configServices/typeorm.config.service.ts
+++ b/src/common/configServices/typeorm.config.service.ts
@@ -10,6 +10,7 @@ export class TypeormConfigService implements TypeOrmOptionsFactory {
         return {
             ...this.configService.getDBConfig(),
             entities: [__dirname + '/../../**/*.entity{.ts,.js}'],
+            keepConnectionAlive: true,
             // dropSchema: true,
         }
     }

--- a/src/discord/services/discord.command.service.ts
+++ b/src/discord/services/discord.command.service.ts
@@ -14,7 +14,7 @@ export class DiscordCommandService {
     private readonly youtube = new Youtube(this.configService.getDiscordConfig().YOUTUBE_API_KEY)
     constructor(
         private readonly configService: AppConfigService,
-        @Inject(forwardRef(() => DiscordClientService)) private readonly discordClientService: DiscordClientService,
+        private readonly discordClientService: DiscordClientService,
         @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: Logger,
     ) {}
 


### PR DESCRIPTION
# Description

- `connection` 유휴상태 이후 `Can't add new command when connection is in closed state` 에러가 발생하는 현상에 대한 해결 방법으로 `keepConnectionAlive: true`옵션을 추가
